### PR TITLE
Implement React homepage with template cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "jszip": "^3.10.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "vite": "^7.0.0"
@@ -440,6 +441,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -944,6 +954,38 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "jszip": "^3.10.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "vite": "^7.0.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,26 @@
 import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import GameGrid from './components/GameGrid.jsx';
+import Reskin from './components/Reskin.jsx';
 
 function App() {
   return (
-    <div className="text-center mt-10 text-2xl font-semibold">
-      Welcome to GameGen!
-    </div>
+    <Router>
+      <div className="container mx-auto p-4">
+        <Routes>
+          <Route
+            path="/"
+            element={(
+              <div>
+                <h1 className="text-3xl font-bold mb-6 text-center">GameGen Templates</h1>
+                <GameGrid />
+              </div>
+            )}
+          />
+          <Route path="/reskin/:template" element={<Reskin />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
 

--- a/src/components/GameCard.jsx
+++ b/src/components/GameCard.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function GameCard({ title, image, template }) {
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow">
+      <img src={image} alt={title} className="w-full h-40 object-cover" />
+      <div className="p-4 flex flex-col items-center gap-2">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <Link
+          to={`/reskin/${template}`}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Customize
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default GameCard;

--- a/src/components/GameGrid.jsx
+++ b/src/components/GameGrid.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import GameCard from './GameCard.jsx';
+
+const games = [
+  { title: 'Flappy Bird', template: 'flappy-bird' },
+  { title: 'Speed Runner', template: 'speed-runner' },
+  { title: 'Whack-a-Mole', template: 'whack-a-mole' },
+  { title: 'Match-3', template: 'match-3' },
+  { title: 'Crossy Road', template: 'crossy-road' },
+];
+
+function GameGrid() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {games.map((game) => (
+        <GameCard
+          key={game.template}
+          title={game.title}
+          image={`https://via.placeholder.com/200?text=${encodeURIComponent(game.title)}`}
+          template={game.template}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default GameGrid;

--- a/src/components/Reskin.jsx
+++ b/src/components/Reskin.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+function Reskin() {
+  const { template } = useParams();
+  const gameTitle = template.replace(/-/g, ' ');
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-4">
+      <h2 className="text-2xl font-bold mb-4 capitalize">Customize {gameTitle}</h2>
+      <p className="mb-6">This is where AI-based reskin options will appear.</p>
+      <Link to="/" className="text-blue-600 hover:underline">Back to home</Link>
+    </div>
+  );
+}
+
+export default Reskin;


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- add modular components for GameCard, GameGrid, Reskin
- route between template list and reskin page
- display responsive grid of game templates with Tailwind styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604aaaad488331908cd7707ee065c8